### PR TITLE
Added an Ingress resource for traffic routing

### DIFF
--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -7,17 +7,17 @@ spec:
   - host: www.dogimages.com
     http:
       paths:
-      - path: /mongo-express
+      - path: /
         pathType: Prefix
         backend:
           service:
             name: mongo-express
             port:
-              number: 30025
-      - path: /dogsimages
+              number: 8081
+      - path: /get-profile
         pathType: Prefix
         backend:
           service:
             name: my-app
             port:
-              number: 30021
+              number: 3000

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mongo-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /mongo-express
+        pathType: Prefix
+        backend:
+          service:
+            name: mongo-express-service
+            port:
+              number: 8081
+      - path: /mongo
+        pathType: Prefix
+        backend:
+          service:
+            name: mongodb-service
+            port:
+              number: 27017
+      

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -6,27 +6,30 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: www.dogimages.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: mongodb-service
-            port:
-              number: 27017
-      - path: /mongo-express
-        pathType: Prefix
-        backend:
-          service:
-            name: mongo-express
-            port:
-              number: 8081
-      - path: /get-profile
-        pathType: Prefix
-        backend:
-          service:
-            name: my-app
-            port:
-              number: 3000
+    - host: www.dogimages.com
+      http:
+        paths:
+          - path: /get-profile
+            pathType: Prefix
+            backend:
+              service:
+                name: my-app
+                port:
+                  number: 3000
+    - host: www.db.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mongo-express
+                port:
+                  number: 8081
+          - path: /mongodb
+            pathType: Prefix
+            backend:
+              service:
+                name: mongodb-service
+                port:
+                  number: 27017

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -16,7 +16,7 @@ spec:
                 name: my-app
                 port:
                   number: 3000
-    - host: www.db.com
+    - host: www.express.com
       http:
         paths:
           - path: /
@@ -26,7 +26,10 @@ spec:
                 name: mongo-express
                 port:
                   number: 8081
-          - path: /mongodb
+    - host: www.mongodb.com
+      http:
+        paths:
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -20,4 +20,3 @@ spec:
             name: mongodb-service
             port:
               number: 27017
-      

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -4,7 +4,7 @@ metadata:
   name: mongo-ingress
 spec:
   rules:
-  - host: app.dogimages.fun
+  - host: www.dogimages.com
     http:
       paths:
       - path: /mongo-express

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -4,19 +4,13 @@ metadata:
   name: mongo-ingress
 spec:
   rules:
-  - http:
+  - host: project.app.internal
+    http:
       paths:
-      - path: /mongo-express
+      - path: /
         pathType: Prefix
         backend:
           service:
-            name: mongo-express-service
+            name: mongo-express
             port:
-              number: 8081
-      - path: /mongo
-        pathType: Prefix
-        backend:
-          service:
-            name: mongodb-service
-            port:
-              number: 27017
+              number: 30025

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -4,13 +4,20 @@ metadata:
   name: mongo-ingress
 spec:
   rules:
-  - host: project.app.internal
+  - host: app.dogimages.fun
     http:
       paths:
-      - path: /
+      - path: /mongo-express
         pathType: Prefix
         backend:
           service:
             name: mongo-express
             port:
               number: 30025
+      - path: /dogsimages
+        pathType: Prefix
+        backend:
+          service:
+            name: my-app
+            port:
+              number: 30021

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -2,12 +2,21 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mongo-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - host: www.dogimages.com
     http:
       paths:
       - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: mongodb-service
+            port:
+              number: 27017
+      - path: /mongo-express
         pathType: Prefix
         backend:
           service:

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -2,22 +2,34 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mongo-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - http:
-      paths:
-      - path: /mongo-express
-        pathType: Prefix
-        backend:
-          service:
-            name: mongo-express-service
-            port:
-              number: 8081
-      - path: /mongo
-        pathType: Prefix
-        backend:
-          service:
-            name: mongodb-service
-            port:
-              number: 27017
-      
+    - host: www.dogimages.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: my-app
+                port:
+                  number: 3000
+    - host: www.db.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mongo-express
+                port:
+                  number: 8081
+          - path: /mongodb
+            pathType: Prefix
+            backend:
+              service:
+                name: mongodb-service
+                port:
+                  number: 27017


### PR DESCRIPTION
- Added an Ingress resource to route traffic to the MongoDB and MongoDB Express services.
- Configured paths /mongo and /mongo-express to route to mongodb-service and mongo-express-service respectively.
